### PR TITLE
Add: chats module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
 import { join } from 'path';
 import { AuthModule } from './auth/auth.module';
+import { ChatsModule } from './chats/chats.module';
 import { RoomsModule } from './rooms/rooms.module';
 import { UsersModule } from './users/users.module';
 
@@ -14,6 +15,7 @@ import { UsersModule } from './users/users.module';
     AuthModule,
     RoomsModule,
     UsersModule,
+    ChatsModule,
   ],
   providers: [],
 })

--- a/src/chats/chats.module.ts
+++ b/src/chats/chats.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from 'src/auth/auth.module';
+import { PrismaService } from 'src/prisma.service';
+import { UsersModule } from 'src/users/users.module';
+import { ChatsResolver } from './chats.resolver';
+import { ChatsService } from './chats.service';
+
+@Module({
+  imports: [AuthModule, UsersModule],
+  providers: [PrismaService, ChatsService, ChatsResolver],
+})
+export class ChatsModule {}

--- a/src/chats/chats.resolver.ts
+++ b/src/chats/chats.resolver.ts
@@ -1,0 +1,59 @@
+import {
+  Args,
+  Query,
+  Resolver,
+  Mutation,
+  ResolveField,
+  Parent,
+} from '@nestjs/graphql';
+import { ChatsService } from './chats.service';
+import { Chat } from './model/Chat';
+import { Chat as ChatFromPrisma, User as UserFromPrisma } from '@prisma/client';
+import { UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+import { CreateChatInput } from './dto/input/create-chat.input';
+import { CurrentUser } from 'src/auth/decorator/CurrentUser';
+import { TokenPayload } from 'src/auth/model/TokenPayload';
+import { User } from 'src/users/model/User';
+import { UsersService } from 'src/users/users.service';
+
+@Resolver(() => Chat)
+export class ChatsResolver {
+  constructor(
+    private readonly chatsService: ChatsService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  @Query(() => [Chat], { name: 'chats', nullable: 'items' })
+  @UseGuards(JwtAuthGuard)
+  async getChats(
+    @CurrentUser() currentUser: TokenPayload,
+    @Args('room_id', { type: () => String }) room_id: string,
+  ): Promise<Omit<Chat, 'sender'>[]> {
+    const { id: user_id } = currentUser;
+    const chats = await this.chatsService.getChats(room_id);
+
+    return chats.map((chat) => ({
+      ...chat,
+      isSender: chat.sender_id === user_id,
+    }));
+  }
+
+  @ResolveField('sender', () => User)
+  async getSender(
+    @Parent() chatFromPrisma: ChatFromPrisma,
+  ): Promise<UserFromPrisma> {
+    const { sender_id } = chatFromPrisma;
+    return this.usersService.getUser(sender_id);
+  }
+
+  @Mutation(() => Chat)
+  @UseGuards(JwtAuthGuard)
+  async createChat(
+    @CurrentUser() currentUser: TokenPayload,
+    @Args('createChatData') createChatData: CreateChatInput,
+  ) {
+    const { id: sender_id } = currentUser;
+    return this.chatsService.createChat(sender_id, createChatData);
+  }
+}

--- a/src/chats/chats.service.ts
+++ b/src/chats/chats.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma.service';
+import { Chat as ChatFromPrisma } from '@prisma/client';
+import { CreateChatInput } from './dto/input/create-chat.input';
+
+@Injectable()
+export class ChatsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createChat(
+    sender_id: string,
+    createChatData: CreateChatInput,
+  ): Promise<ChatFromPrisma> {
+    return this.prisma.chat.create({
+      data: {
+        sender_id,
+        ...createChatData,
+      },
+    });
+  }
+
+  async getChats(room_id: string): Promise<ChatFromPrisma[]> {
+    return this.prisma.chat.findMany({
+      where: { room_id },
+      orderBy: { created_at: 'desc' },
+    });
+  }
+}

--- a/src/chats/dto/input/create-chat.input.ts
+++ b/src/chats/dto/input/create-chat.input.ts
@@ -1,0 +1,13 @@
+import { InputType, Field } from '@nestjs/graphql';
+import { IsNotEmpty } from 'class-validator';
+
+@InputType()
+export class CreateChatInput {
+  @Field()
+  @IsNotEmpty()
+  room_id: string;
+
+  @Field()
+  @IsNotEmpty()
+  content: string;
+}

--- a/src/chats/model/Chat.ts
+++ b/src/chats/model/Chat.ts
@@ -1,0 +1,24 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { Chat as ChatFromPrisma } from '@prisma/client';
+import { User } from 'src/users/model/User';
+
+@ObjectType()
+export class Chat implements Omit<ChatFromPrisma, 'sender_id'> {
+  @Field()
+  id: string;
+
+  @Field()
+  content: string;
+
+  @Field()
+  created_at: Date;
+
+  @Field()
+  room_id: string;
+
+  @Field()
+  isSender: boolean;
+
+  @Field(() => User)
+  sender: User;
+}

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -21,6 +21,15 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 """
 scalar DateTime
 
+type Chat {
+  id: String!
+  content: String!
+  created_at: DateTime!
+  room_id: String!
+  isSender: Boolean!
+  sender: User!
+}
+
 type RoomStatus {
   id: Int!
   name: String!
@@ -44,6 +53,7 @@ type Query {
   loginByGoogle(google_token: String!): Token
   testerLogin(tester_id: String!): Token
   rooms: [Room]!
+  chats(room_id: String!): [Chat]!
 }
 
 type Mutation {
@@ -53,6 +63,7 @@ type Mutation {
   completeRoom(completeRoomData: CompleteRoomInput!): Room!
   cancleRoom(room_id: String!): Room!
   saveReceiver(room_id: String!): Room!
+  createChat(createChatData: CreateChatInput!): Chat!
 }
 
 input CreateRoomInput {
@@ -75,4 +86,9 @@ input CompleteRoomInput {
   room_id: String!
   completed_time: DateTime!
   location: String!
+}
+
+input CreateChatInput {
+  room_id: String!
+  content: String!
 }


### PR DESCRIPTION
## 변경사항

- 채팅방과 관련한 chats API 

### 1. Chat Model
```ts

@ObjectType()
export class Chat implements Omit<ChatFromPrisma, 'sender_id'> {
  @Field()
  id: string;

  @Field()
  content: string;

  @Field()
  created_at: Date;

  @Field()
  room_id: string;

  @Field()
  isSender: boolean; // 현재 채팅 정보를 요청한 유저가 메세지를 보낸 사람인지 아닌지 판별하는 필드

  @Field(() => User)
  sender: User;
}
```

### 2. [Query] chats
```ts
  @Query(() => [Chat], { name: 'chats', nullable: 'items' })
  @UseGuards(JwtAuthGuard)
  async getChats(
    @CurrentUser() currentUser: TokenPayload,
    @Args('room_id', { type: () => String }) room_id: string,
  ): Promise<Omit<Chat, 'sender'>[]> {
    const { id: user_id } = currentUser;
    const chats = await this.chatsService.getChats(room_id);

    return chats.map((chat) => ({
      ...chat,
      isSender: chat.sender_id === user_id,
    }));
  }
```
- Jwt 가드로 현재 유저의 정보 가려낸 다음
- 서비스 로직을 이용해서 해당 방에 대한 채팅 내용을 쿼리하고
- 메세지를 보낸 사람인지 아닌지 chat row 에 저장되어 있는 sender_id 를 통해 판별한다.

**NextStep**
- Pagination 기능 추가 되어야 함
- Chat Page Component 에서 어떻게 데이터가 보여질지 고민 후 API 수정 필요함 

### 3. [Mutation] createChat
- 다음과 같은 InputType 과 토큰에 담긴 user_id 를 통해 메세지를 저장한다.
```ts
@InputType()
export class CreateChatInput {
  @Field()
  @IsNotEmpty()
  room_id: string;

  @Field()
  @IsNotEmpty()
  content: string;
}
```