### PR TITLE
Add: saveLastViewedChat Mutation

### DIFF
--- a/src/chats/chats.resolver.ts
+++ b/src/chats/chats.resolver.ts
@@ -17,6 +17,7 @@ import { TokenPayload } from 'src/auth/model/TokenPayload';
 import { User } from 'src/users/model/User';
 import { UsersService } from 'src/users/users.service';
 import { GetChatsArgs } from './dto/args/get-chats.args';
+import { SaveLastViewedChatInput } from './dto/input/save-last-viewed-chat.input';
 
 @Resolver(() => Chat)
 export class ChatsResolver {
@@ -49,8 +50,22 @@ export class ChatsResolver {
   async createChat(
     @CurrentUser() currentUser: TokenPayload,
     @Args('createChatData') createChatData: CreateChatInput,
-  ) {
+  ): Promise<Omit<Chat, 'sender'>> {
     const { id: sender_id } = currentUser;
     return this.chatsService.createChat(sender_id, createChatData);
+  }
+
+  @Mutation(() => Chat)
+  @UseGuards(JwtAuthGuard)
+  async saveLastViewedChat(
+    @CurrentUser() currentUser: TokenPayload,
+    @Args('saveLastViewedChatData')
+    saveLastViewedChatData: SaveLastViewedChatInput,
+  ): Promise<Omit<Chat, 'sender'>> {
+    const { id: user_id } = currentUser;
+    return this.chatsService.saveLastViewedChat(
+      user_id,
+      saveLastViewedChatData,
+    );
   }
 }

--- a/src/chats/chats.service.ts
+++ b/src/chats/chats.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma.service';
-import { Chat as ChatFromPrisma } from '@prisma/client';
 import { CreateChatInput } from './dto/input/create-chat.input';
 import { GetChatsArgs } from './dto/args/get-chats.args';
 import { Chat } from './model/Chat';
+import { SaveLastViewedChatInput } from './dto/input/save-last-viewed-chat.input';
 
 @Injectable()
 export class ChatsService {
@@ -12,13 +12,18 @@ export class ChatsService {
   async createChat(
     sender_id: string,
     createChatData: CreateChatInput,
-  ): Promise<ChatFromPrisma> {
-    return this.prisma.chat.create({
+  ): Promise<Omit<Chat, 'sender'>> {
+    const createdChat = await this.prisma.chat.create({
       data: {
         sender_id,
         ...createChatData,
       },
     });
+
+    return {
+      ...createdChat,
+      isSender: createdChat.sender_id === sender_id,
+    };
   }
 
   async getChats(
@@ -41,5 +46,51 @@ export class ChatsService {
         isSender: chat.sender_id === user_id,
       }))
       .sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+  }
+
+  async getLastViewedChat(
+    room_id: string,
+    user_id: string,
+  ): Promise<Omit<Chat, 'sender'> | null> {
+    const foundChat = await this.prisma.lastViewedChat
+      .findUnique({
+        where: {
+          user_id_room_id: {
+            user_id,
+            room_id,
+          },
+        },
+      })
+      .chat();
+
+    if (!foundChat) return null;
+
+    return {
+      ...foundChat,
+      isSender: foundChat.sender_id === user_id,
+    };
+  }
+
+  async saveLastViewedChat(
+    user_id: string,
+    saveLastViedChatData: SaveLastViewedChatInput,
+  ): Promise<Omit<Chat, 'sender'>> {
+    const savedLastViewdChat = await this.prisma.lastViewedChat
+      .upsert({
+        where: {
+          user_id_room_id: {
+            user_id,
+            room_id: saveLastViedChatData.room_id,
+          },
+        },
+        update: { chat_id: saveLastViedChatData.chat_id },
+        create: { user_id, ...saveLastViedChatData },
+      })
+      .chat();
+
+    return {
+      ...savedLastViewdChat,
+      isSender: savedLastViewdChat.sender_id === user_id,
+    };
   }
 }

--- a/src/chats/dto/input/save-last-viewed-chat.input.ts
+++ b/src/chats/dto/input/save-last-viewed-chat.input.ts
@@ -1,0 +1,13 @@
+import { InputType, Field } from '@nestjs/graphql';
+import { IsNotEmpty } from 'class-validator';
+
+@InputType()
+export class SaveLastViewedChatInput {
+  @Field()
+  @IsNotEmpty()
+  room_id: string;
+
+  @Field()
+  @IsNotEmpty()
+  chat_id: string;
+}

--- a/src/rooms/model/Coords.ts
+++ b/src/rooms/model/Coords.ts
@@ -1,0 +1,10 @@
+import { Field, Float, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class Coords {
+  @Field(() => Float)
+  longitude: number;
+
+  @Field(() => Float)
+  latitude: number;
+}

--- a/src/rooms/model/Room.ts
+++ b/src/rooms/model/Room.ts
@@ -3,11 +3,15 @@ import { Room as RoomFromPrisma } from '@prisma/client';
 import { RoomStatus } from './RoomStatus';
 import { User } from 'src/users/model/User';
 import { Chat } from 'src/chats/model/Chat';
+import { Coords } from './Coords';
 
 @ObjectType()
 export class Room
   implements
-    Omit<RoomFromPrisma, 'room_status_id' | 'receiver_id' | 'inviter_id'> {
+    Omit<
+      RoomFromPrisma,
+      'room_status_id' | 'receiver_id' | 'inviter_id' | 'location'
+    > {
   @Field()
   id: string;
 
@@ -46,4 +50,7 @@ export class Room
 
   @Field(() => [Chat], { nullable: 'items' })
   chats: Chat[];
+
+  @Field(() => Chat, { nullable: true })
+  lastViewedChat: Chat;
 }

--- a/src/rooms/rooms.resolver.ts
+++ b/src/rooms/rooms.resolver.ts
@@ -28,6 +28,7 @@ import { ROOM_STATUS_ID } from 'src/util/constans';
 import { Chat } from 'src/chats/model/Chat';
 import { ChatsService } from 'src/chats/chats.service';
 import { GetChatsArgs } from 'src/chats/dto/args/get-chats.args';
+import { Coords } from './model/Coords';
 
 type RoomWithUserId = RoomFromPrisma & { user_id: string };
 
@@ -96,6 +97,14 @@ export class RoomsResolver {
     });
 
     return recentChat;
+  }
+
+  @ResolveField('lastViewedChat', () => Chat, { nullable: true })
+  async getLastViewedChat(
+    @Parent() roomWithUserId: RoomWithUserId,
+  ): Promise<Omit<Chat, 'sender'>> {
+    const { id: room_id, user_id } = roomWithUserId;
+    return this.chatsService.getLastViewedChat(room_id, user_id);
   }
 
   @ResolveField('chats', () => [Chat])

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -21,6 +21,7 @@ export class RoomsService {
       where: {
         OR: [{ inviter_id: user_id }, { receiver_id: user_id }],
       },
+      orderBy: { created_at: 'desc' },
     });
   }
 

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -56,6 +56,7 @@ type Room {
   location: String
   recentChat: Chat
   chats(offset: Int, limit: Int): [Chat!]!
+  lastViewedChat: Chat
 }
 
 type Query {
@@ -74,6 +75,7 @@ type Mutation {
   cancleRoom(room_id: String!): Room!
   saveReceiver(room_id: String!): Room!
   createChat(createChatData: CreateChatInput!): Chat!
+  saveLastViewedChat(saveLastViewedChatData: SaveLastViewedChatInput!): Chat!
 }
 
 input CreateRoomInput {
@@ -103,4 +105,9 @@ input CreateChatInput {
   room_id: String!
   content: String!
   created_at: DateTime
+}
+
+input SaveLastViewedChatInput {
+  room_id: String!
+  chat_id: String!
 }


### PR DESCRIPTION
## LastViewedChat Model Added 

### [Mutation] saveLastViewedChat 
- 토큰 페이로드에 담겨온 user_id 
- 뮤테이션의 인자로 받는 room_id, chat_id 를 중간테이블에 저장한다. 
- **prisma upsert** 메소드를 사용해서 없으면 추가하고, 있으면 update 하도록 함 
> **chats.service.ts**
```ts
  async saveLastViewedChat(
    user_id: string,
    saveLastViedChatData: SaveLastViewedChatInput,
  ): Promise<Omit<Chat, 'sender'>> {
    const savedLastViewdChat = await this.prisma.lastViewedChat
      .upsert({
        where: {
          user_id_room_id: {
            user_id,
            room_id: saveLastViedChatData.room_id,
          },
        },
        update: { chat_id: saveLastViedChatData.chat_id },
        create: { user_id, ...saveLastViedChatData },
      })
      .chat();

    return {
      ...savedLastViewdChat,
      isSender: savedLastViewdChat.sender_id === user_id,
    };
  }
```

### Room Type: lastViewedChat 필드 | 리졸버 추가 
- 토큰에 담겨온 유저가 가장 마지막에 본 메세지를 Query 할 수 있음
- Chat 타입을 리턴하도록 함 

> **rooms.resolve.ts**
```ts
  @ResolveField('lastViewedChat', () => Chat, { nullable: true })
  async getLastViewedChat(
    @Parent() roomWithUserId: RoomWithUserId,
  ): Promise<Omit<Chat, 'sender'>> {
    const { id: room_id, user_id } = roomWithUserId;
    return this.chatsService.getLastViewedChat(room_id, user_id);
  }
```

### Next Action
- Coords 커스텀 스칼라 타입을 지정해서, location 의 타입을 Coords 로 선언하기 
- createRoom 의 input 타입, rooms, room 쿼리에서 객체의 형식으로 꺼내올 수 있도록 리졸버 구현하기 