### PR TITLE
Modify: location Coords | Coords Input Type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 .env
+.env.production

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "deploy": "cross-env NODE_ENV=production sls deploy"
   },
   "dependencies": {
     "@nestjs/common": "^7.5.1",
@@ -55,6 +56,7 @@
     "@types/supertest": "^2.0.10",
     "@typescript-eslint/eslint-plugin": "^4.6.1",
     "@typescript-eslint/parser": "^4.6.1",
+    "cross-env": "^7.0.3",
     "eslint": "^7.12.1",
     "eslint-config-prettier": "7.2.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/src/auth/auth.resolver.ts
+++ b/src/auth/auth.resolver.ts
@@ -30,4 +30,9 @@ export class AuthResolver {
     console.log('id from client!', id);
     return `hello! ${id}`;
   }
+
+  @Query(() => String, { nullable: true })
+  testerLogin(@Args('id') id: string) {
+    return this.authService.testerLogin(id);
+  }
 }

--- a/src/rooms/dto/input/complete-room.input.ts
+++ b/src/rooms/dto/input/complete-room.input.ts
@@ -1,5 +1,6 @@
 import { InputType, Field } from '@nestjs/graphql';
-import { IsNotEmpty, Contains } from 'class-validator';
+import { IsNotEmpty, IsObject } from 'class-validator';
+import { CoordsInput } from 'src/rooms/model/Room';
 
 @InputType()
 export class CompleteRoomInput {
@@ -11,9 +12,8 @@ export class CompleteRoomInput {
   @IsNotEmpty()
   completed_time: Date;
 
-  @Field()
+  @Field(() => CoordsInput)
+  @IsObject()
   @IsNotEmpty()
-  @Contains('longitude')
-  @Contains('latitude')
-  location: string;
+  location: CoordsInput;
 }

--- a/src/rooms/dto/input/create-room.input.ts
+++ b/src/rooms/dto/input/create-room.input.ts
@@ -1,10 +1,11 @@
 import { InputType, Field } from '@nestjs/graphql';
-import { IsNotEmpty, Contains, IsOptional } from 'class-validator';
+import { IsNotEmpty, IsObject, IsOptional } from 'class-validator';
 import { Room as RoomFromPrisma } from '@prisma/client';
+import { CoordsInput } from 'src/rooms/model/Room';
 
 @InputType()
 export class CreateRoomInput
-  implements Pick<RoomFromPrisma, 'title' | 'reserved_time' | 'location'> {
+  implements Pick<RoomFromPrisma, 'title' | 'reserved_time'> {
   @Field()
   @IsNotEmpty()
   title: string;
@@ -14,10 +15,9 @@ export class CreateRoomInput
   @IsNotEmpty()
   reserved_time: Date;
 
-  @Field({ nullable: true })
-  @IsOptional()
+  @Field(() => CoordsInput, { nullable: true })
+  @IsObject()
   @IsNotEmpty()
-  @Contains('longitude')
-  @Contains('latitude')
-  location: string;
+  @IsOptional()
+  location: CoordsInput;
 }

--- a/src/rooms/dto/input/update-location.input.ts
+++ b/src/rooms/dto/input/update-location.input.ts
@@ -1,5 +1,6 @@
 import { InputType, Field } from '@nestjs/graphql';
-import { IsNotEmpty, Contains } from 'class-validator';
+import { IsNotEmpty, IsObject } from 'class-validator';
+import { CoordsInput } from 'src/rooms/model/Room';
 
 @InputType()
 export class UpdateLocationInput {
@@ -7,9 +8,8 @@ export class UpdateLocationInput {
   @IsNotEmpty()
   room_id: string;
 
-  @Field()
+  @Field(() => CoordsInput)
+  @IsObject()
   @IsNotEmpty()
-  @Contains('longitude')
-  @Contains('latitude')
-  location: string;
+  location: CoordsInput;
 }

--- a/src/rooms/dto/input/update-room.input.ts
+++ b/src/rooms/dto/input/update-room.input.ts
@@ -1,5 +1,5 @@
 export interface IUpdateRoomInput {
-  location?: string;
+  location?: string; // (location) => JSON.strigify(location)
   reserved_time?: Date;
   completed_time?: Date;
   room_status_id?: number;

--- a/src/rooms/model/Room.ts
+++ b/src/rooms/model/Room.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType, InputType, Float } from '@nestjs/graphql';
 import { Room as RoomFromPrisma } from '@prisma/client';
 import { RoomStatus } from './RoomStatus';
 import { User } from 'src/users/model/User';
@@ -42,8 +42,8 @@ export class Room
   @Field(() => User)
   inviter: User;
 
-  @Field({ nullable: true })
-  location: string;
+  @Field(() => Coords, { nullable: true })
+  location: Coords;
 
   @Field(() => Chat, { nullable: true })
   recentChat: Chat;
@@ -53,4 +53,13 @@ export class Room
 
   @Field(() => Chat, { nullable: true })
   lastViewedChat: Chat;
+}
+
+@InputType()
+export class CoordsInput {
+  @Field(() => Float)
+  longitude: number;
+
+  @Field(() => Float)
+  latitude: number;
 }

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -30,8 +30,8 @@ export class RoomsService {
   }
 
   async createRoom(
-    createRoomData: CreateRoomInput,
     inviter_id: string,
+    createRoomData: CreateRoomInput,
   ): Promise<RoomFromPrisma> {
     return this.prisma.room.create({
       data: {
@@ -49,20 +49,9 @@ export class RoomsService {
     room_id: string,
     updateRoomData: IUpdateRoomInput,
   ): Promise<RoomFromPrisma> {
-    const updatePayload: IUpdateRoomInput = Object.keys(updateRoomData).reduce(
-      (payload, field) => {
-        payload[field] =
-          field === 'location'
-            ? JSON.stringify(updateRoomData.location)
-            : updateRoomData[field];
-        return payload;
-      },
-      {},
-    );
-
     return this.prisma.room.update({
       where: { id: room_id },
-      data: updatePayload,
+      data: updateRoomData,
     });
   }
 }

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -42,6 +42,11 @@ type RoomStatus {
   name: String!
 }
 
+type Coords {
+  longitude: Float!
+  latitude: Float!
+}
+
 type Room {
   id: String!
   title: String!
@@ -53,7 +58,7 @@ type Room {
   roomStatus: RoomStatus!
   receiver: User
   inviter: User!
-  location: String
+  location: Coords
   recentChat: Chat
   chats(offset: Int, limit: Int): [Chat!]!
   lastViewedChat: Chat
@@ -62,6 +67,7 @@ type Room {
 type Query {
   loginByGoogle(google_token: String!): UserWithToken
   authTest: String
+  testerLogin(id: String!): String
   rooms: [Room]!
   room(room_id: String!): Room
   chats(offset: Int, limit: Int, room_id: String!): [Chat]!
@@ -81,7 +87,12 @@ type Mutation {
 input CreateRoomInput {
   title: String!
   reserved_time: DateTime
-  location: String
+  location: CoordsInput
+}
+
+input CoordsInput {
+  longitude: Float!
+  latitude: Float!
 }
 
 input UpdateReservedTimeInput {
@@ -91,13 +102,13 @@ input UpdateReservedTimeInput {
 
 input UpdateLocationInput {
   room_id: String!
-  location: String!
+  location: CoordsInput!
 }
 
 input CompleteRoomInput {
   room_id: String!
   completed_time: DateTime!
-  location: String!
+  location: CoordsInput!
 }
 
 input CreateChatInput {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3457,6 +3457,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@3.0.6, cross-fetch@^3.0.4:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
@@ -3475,7 +3482,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
## Coords Type 추가

> **rooms/model/coords.ts**

- JSON.stringify 로 Client 에서 이미 JSON 화된 객체가, 백엔드 측에서 또 JSON.stringify 를 통해서 DB에 적재되고 있었음.
- 두 번의 JSON.stringify 적용으로 parse 를 했을 때, 객체로 접근되지 않는 문제 발생 
- longitude, latitude 를 property 로 가지는 Coords 타입 추가하고, 리졸버 구현 
```ts
import { Field, Float, ObjectType } from '@nestjs/graphql';

@ObjectType()
export class Coords {
  @Field(() => Float)
  longitude: number;

  @Field(() => Float)
  latitude: number;
}
```

>  **rooms.resolver.tes**
- Room 타입에 nesting 된 형태로 리졸버 구현 

```ts
  @ResolveField('location', () => Coords, { nullable: true })
  location(@Parent() roomFromPrisma: RoomFromPrisma): Coords {
    const { location } = roomFromPrisma;
    return JSON.parse(location as string) as Coords;
  }
```

## Playground 
<img width="1214" alt="Screen Shot 2021-03-15 at 1 18 43 AM" src="https://user-images.githubusercontent.com/63147802/111095229-5dbe6900-8580-11eb-98c6-d1f59c9f1921.png">
<img width="1256" alt="Screen Shot 2021-03-15 at 1 19 04 AM" src="https://user-images.githubusercontent.com/63147802/111095238-60b95980-8580-11eb-9873-29b2194a8de0.png">
<img width="1316" alt="Screen Shot 2021-03-15 at 1 19 20 AM" src="https://user-images.githubusercontent.com/63147802/111095253-64e57700-8580-11eb-91f6-fa5c36baeee5.png">

