### PR TITLE
Delete: refreshToken Query useGuards | Modify: refreshToken Query

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -92,4 +92,12 @@ export class AuthService {
       refresh_token,
     };
   }
+
+  verifyRefreshToken(refresh_token: string) {
+    const { id }: TokenPayload = this.jwtService.verify(refresh_token, {
+      secret: process.env.REFRESH_TOKEN_SALT,
+    });
+
+    return id;
+  }
 }

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -76,7 +76,6 @@ type Room {
 type Query {
   loginByGoogle(google_token: String!): UserWithToken
   refreshToken: UserWithToken
-  testerLogin(id: String!): String!
   rooms: [Room]!
   room(room_id: String!): Room
   chats(offset: Int, limit: Int, room_id: String!): [Chat]!


### PR DESCRIPTION
## useGuards 로 access_token 가져오는 로직 삭제
- refreshToken Query 에 useGuards 로 access_token 을 검증하게 되면, 
페이지를 다시 열었을 때, 다시 접속했을 때 로그인을 해야한다. 
- 원래 취지에 맞지 않는 검증과정 이므로 삭제 함.

## httpOnly 쿠키에 담겨있는 refreshToken 으로 user 의 고유한 id 조회 하도록 함